### PR TITLE
fix: field resolver for deployedChain type

### DIFF
--- a/packages/nextjs/utils/graphclient/resolvers.ts
+++ b/packages/nextjs/utils/graphclient/resolvers.ts
@@ -3,6 +3,16 @@ import { Resolvers } from "../../.graphclient";
 const chains = ["arbitrum", "mainnet"];
 
 export const resolvers: Resolvers = {
+  Subgraph: {
+    deployedChain: async root => {
+      if (!root.deployedChain) {
+        // we are always passing this from the query resolver
+        // in case it isn't reached here we should panic.
+        throw new Error("deployedChain not found");
+      }
+      return root.deployedChain;
+    },
+  },
   Query: {
     crossSubgraphs: async (root: any, args: any, context: any, info: any) => {
       console.log("crossSubgraphs", root, args, context, info);


### PR DESCRIPTION
Since we extend the `Subgraph` type to include `deployedChain` we should make sure we are returning results when that happens. We can grab this info from the `root` field since we are mapping over the datasources and providing that field.

